### PR TITLE
Agressive test friendly refactor

### DIFF
--- a/cmd/pkgproto/main.go
+++ b/cmd/pkgproto/main.go
@@ -2,23 +2,27 @@ package main
 
 import (
 	"bufio"
-	"os"
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/Projeto-Pindorama/motoko/internal/archivum"
 )
 
 func main() {
+	fs := archivum.NewUnixFS("/")
 	readstdin := bufio.NewScanner(os.Stdin)
 	for readstdin.Scan() {
-		Metadata := archivum.Scan(readstdin.Text())
-		fmt.Printf("%c %s %s %s %s %s %s\n",
-		Metadata.FType,
-		Metadata.Path,
-		Metadata.Major,
-		Metadata.Minor,
-		Metadata.OctalMod,
-		Metadata.Owner,
-		Metadata.Group)
+		metadata, err := archivum.Scan(fs, readstdin.Text())
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Printf("%c %s %s %s %s\n",
+			metadata.FType,
+			metadata.Path,
+			metadata.OctalMod,
+			metadata.Owner,
+			metadata.Group)
 	}
 }

--- a/cmd/pkgproto/main.go
+++ b/cmd/pkgproto/main.go
@@ -18,11 +18,6 @@ func main() {
 			log.Fatal(err)
 		}
 
-		fmt.Printf("%c %s %s %s %s\n",
-			metadata.FType,
-			metadata.Path,
-			metadata.OctalMod,
-			metadata.Owner,
-			metadata.Group)
+		fmt.Println(archivum.MetadataToString(metadata))
 	}
 }

--- a/internal/archivum/device.go
+++ b/internal/archivum/device.go
@@ -1,0 +1,18 @@
+package archivum
+
+type DeviceInfo struct {
+	Major, Minor uint32
+}
+
+func deviceInfoByDev(dev uint64) *DeviceInfo {
+	major := uint32((dev & 0x00000000000fff00) >> 8)
+	major |= uint32((dev & 0xfffff00000000000) >> 32)
+	minor := uint32((dev & 0x00000000000000ff) >> 0)
+	minor |= uint32((dev & 0x00000ffffff00000) >> 12)
+
+	return &DeviceInfo{
+		Major: major,
+		Minor: minor,
+	}
+
+}

--- a/internal/archivum/filesystem.go
+++ b/internal/archivum/filesystem.go
@@ -2,16 +2,75 @@ package archivum
 
 import (
 	"io/fs"
+	"os"
 	"os/user"
+	"syscall"
 )
 
-type OwnershipFS interface {
+type OperatingSystemFS interface {
 	fs.FS
-	StatOwned(name string) OwnedFileInfo // avoid conflicts when embedding StatFS
+
+	Stat(name string) (OSFileInfo, error)
 }
 
-type OwnedFileInfo interface {
+type OSFileInfo interface {
 	fs.FileInfo
+
 	Group() *user.Group
-	User() *user.User
+	Owner() *user.User
+	DeviceInfo() *DeviceInfo
+}
+
+type UnixFS struct {
+	fs.FS
+}
+
+type UnixFileInfo struct {
+	fs.FileInfo
+	group *user.Group
+	owner *user.User
+}
+
+func NewUnixFS(path string) UnixFS {
+	return UnixFS{os.DirFS(path)}
+}
+
+func (fs UnixFS) Stat(name string) (OSFileInfo, error) {
+	fileInfo, err := os.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+
+	sysInfo := fileInfo.Sys().(*syscall.Stat_t)
+
+	owner, err := userByUID(sysInfo.Uid)
+	if err != nil {
+		return nil, err
+	}
+
+	group, err := groupByGID(sysInfo.Gid)
+	if err != nil {
+		return nil, err
+	}
+
+	unixFileInfo := UnixFileInfo{
+		FileInfo: fileInfo,
+		group:    group,
+		owner:    owner,
+	}
+
+	return unixFileInfo, nil
+}
+
+func (fi UnixFileInfo) Owner() *user.User {
+	return fi.owner
+}
+
+func (fi UnixFileInfo) Group() *user.Group {
+	return fi.group
+}
+
+func (fi UnixFileInfo) DeviceInfo() *DeviceInfo {
+	sysInfo := fi.Sys().(*syscall.Stat_t)
+	return deviceInfoByDev(sysInfo.Rdev)
 }

--- a/internal/archivum/filesystem.go
+++ b/internal/archivum/filesystem.go
@@ -1,0 +1,17 @@
+package archivum
+
+import (
+	"io/fs"
+	"os/user"
+)
+
+type OwnershipFS interface {
+	fs.FS
+	StatOwned(name string) OwnedFileInfo // avoid conflicts when embedding StatFS
+}
+
+type OwnedFileInfo interface {
+	fs.FileInfo
+	Group() *user.Group
+	User() *user.User
+}

--- a/internal/archivum/helpers.go
+++ b/internal/archivum/helpers.go
@@ -1,0 +1,14 @@
+package archivum
+
+import (
+	"os/user"
+	"strconv"
+)
+
+func groupByGID(gid uint32) (*user.Group, error) {
+	return user.LookupGroupId(strconv.FormatUint(uint64(gid), 10))
+}
+
+func userByUID(uid uint32) (*user.User, error) {
+	return user.LookupId(strconv.FormatUint(uint64(uid), 10))
+}

--- a/internal/archivum/meta.go
+++ b/internal/archivum/meta.go
@@ -13,8 +13,6 @@ import (
 	"os/user"
 	"strconv"
 	"syscall"
-
-	"github.com/Projeto-Pindorama/motoko/internal/pfmt"
 )
 
 type Metadata struct {

--- a/internal/archivum/meta.go
+++ b/internal/archivum/meta.go
@@ -40,8 +40,7 @@ func Scan(path string) (*Metadata, error) {
 	ftype := determineFType(fi)
 	fstat := fi.Sys().(*syscall.Stat_t)
 
-	/* Something that is valid to note: minor/major numbers are only used in
-	* device files */
+	// minor/major numbers are only used in device files */
 	var majorNumber, minorNumber string
 	if (ftype == 'c') || (ftype == 'b') {
 		majorNumber, minorNumber = "nil", "nil"
@@ -49,18 +48,11 @@ func Scan(path string) (*Metadata, error) {
 
 	/* octalPermissions := */
 
-	/* This is pathetic. We're converting our UID (and GID too) to uint64,
-	* then converting it to a string using FormatUint; why Go doesn't do
-	* this in a more on-the-fly way? Well, I think this library exists for a
-	* reason then. */
 	getOwner, _ := user.LookupId(strconv.FormatUint(uint64(fstat.Uid), 10))
 	getGroup, _ := user.LookupGroupId(strconv.FormatUint(uint64(fstat.Gid), 10))
 	ownerPermissions := getOwner.Username
 	groupPermissions := getGroup.Name
 
-	/* If it's a symbolic link, print a error saying that these aren't
-	*  supported. I'm almost changing of idea in this subject, may we
-	*  couldn't support links, but at least we could use the real file, eh? */
 	if ftype == 's' {
 		return nil, fmt.Errorf("%w <%s>", errSLink, path)
 	}

--- a/internal/archivum/meta.go
+++ b/internal/archivum/meta.go
@@ -30,7 +30,7 @@ const (
 	errSLink = "symbolic links are not supported <%s>\n"
 )
 
-func Scan(path string) Metadata {
+func Scan(path string) (*Metadata, error) {
 	fi, err := os.Lstat(path)
 	if os.IsNotExist(err) {
 		pfmt.Pfmt(os.Stderr, "MM_ERROR", errStat, path)

--- a/internal/archivum/meta.go
+++ b/internal/archivum/meta.go
@@ -55,6 +55,31 @@ func Scan(dir OperatingSystemFS, path string) (*Metadata, error) {
 	return Data, nil
 }
 
+func MetadataToString(m *Metadata) string {
+	if m.DeviceInfo == nil {
+		return fmt.Sprintf(
+			"%c %s %s %s %s\n",
+			m.FType,
+			m.Path,
+			m.OctalMod,
+			m.Owner,
+			m.Group,
+		)
+	} else {
+		return fmt.Sprintf(
+			"%c %s %d %d %s %s %s\n",
+			m.FType,
+			m.Path,
+			m.DeviceInfo.Major,
+			m.DeviceInfo.Minor,
+			m.OctalMod,
+			m.Owner,
+			m.Group,
+		)
+	}
+
+}
+
 func determineFType(fi os.FileInfo) rune {
 	switch mode := fi.Mode(); {
 	case mode.IsRegular():


### PR DESCRIPTION
A somewhat large refactor was made to the internal library "archivum", which makes uses of Go interfaces instead of relying directly syscalls, so that testing becomes easier. Also, me minor/major file mode determination was implemented, along with different formatting for files which contain it, and for those that don't.